### PR TITLE
Fixes/enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ os:
     - osx
     - linux
 julia:
-    - release
+    - 0.4
+    - 0.5
+    - nightly
 notifications:
   email: false
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/lejon/TSne.jl.svg?branch=master)](https://travis-ci.org/lejon/TSne.jl) 
+[![Travis](https://travis-ci.org/lejon/TSne.jl.svg?branch=master)](https://travis-ci.org/lejon/TSne.jl)
+[![Coveralls](https://coveralls.io/repos/github/lejon/TSne.jl/badge.svg?branch=master)](https://coveralls.io/github/lejon/TSne.jl?branch=master)
 
 julia-tsne
 ==========

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
+Compat 0.9
 FactCheck
 RDatasets
 MNIST

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -114,6 +114,7 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
     verbose && info("Initial X Shape is $(size(X))")
 
     # Initialize variables
+    X = scale(X, 1.0/std(X))
     if initial_dims>0
         X = pca(X, initial_dims)
     end

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -154,8 +154,9 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
         # FIXME profiling indicates a lot of time is lost in copytri!()
         A_mul_Bt!(Q, Y, Y)
         @inbounds for j in 1:size(Q, 2)
+            Q[j,j] = 0.0
             @simd for i in 1:(j-1)
-                Q[j,i] = Q[i,j] = 1.0 / (1.0 - 2.0 * Q[i,j] + sum_YY[i] + sum_YY[j])
+                Q[j,i] = Q[i,j] = 1.0 / max(1.0, 1.0 - 2.0 * Q[i,j] + sum_YY[i] + sum_YY[j])
             end
         end
         sum_Q = sum(Q)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -120,10 +120,11 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter:
               stop_cheat_iter::Integer = 250, cheat_scale::Number = 12.0,
               verbose::Bool = false, progress::Bool=true)
     verbose && info("Initial X Shape is $(size(X))")
+    ndims < size(X, 2) || throw(ArgumentError("X has fewer dimensions ($(size(X,2))) than ndims=$ndims"))
 
     # Initialize variables
     X = scale(X, 1.0/std(X))
-    if reduce_dims>0
+    if reduce_dims>0 && reduce_dims < size(X, 2)
         reduce_dims = max(reduce_dims, ndims)
         verbose && info("Preprocessing the data using PCA...")
         X = pca(X, reduce_dims)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -98,7 +98,6 @@ end
     FIXME use PCA routine from JuliaStats?
 """
 function pca{T}(X::Matrix{T}, ndims::Integer = 50)
-    info("Preprocessing the data using PCA...")
     (n, d) = size(X)
     X = X - repmat(mean(X, 1), n, 1)
     C = (X' * X) ./ (size(X,1)-1)
@@ -115,7 +114,7 @@ end
     Different from the orginal implementation,
     the default is not to use PCA for initialization.
 """
-function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter::Integer = 1000, perplexity::Number = 30.0;
+function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter::Integer = 1000, perplexity::Number = 30.0;
               min_gain::Number = 0.01, eta::Number = 200.0,
               initial_momentum::Number = 0.5, final_momentum::Number = 0.8, momentum_switch_iter::Integer = 250,
               stop_cheat_iter::Integer = 250, cheat_scale::Number = 12.0,
@@ -124,8 +123,10 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
 
     # Initialize variables
     X = scale(X, 1.0/std(X))
-    if initial_dims>0
-        X = pca(X, initial_dims)
+    if reduce_dims>0
+        reduce_dims = max(reduce_dims, ndims)
+        verbose && info("Preprocessing the data using PCA...")
+        X = pca(X, reduce_dims)
     end
     (n, d) = size(X)
     Y = randn(n, ndims)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -44,12 +44,12 @@ function perplexities(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
     verbose && info("Computing pairwise distances...")
     (n, d) = size(X)
     sum_XX = sumabs2(X, 2)
-    D = -2 * (X*X') .+ sum_XX .+ sum_XX'
+    D = -2 * (X*X') .+ sum_XX .+ sum_XX' # euclidean distances between the points
+    P = zeros(n, n) # perplexities matrix
+    beta = ones(n)  # vector of Normal distribution precisions for each point
+    logU = log(perplexity) # the log of expected perplexity
     Di = zeros(n)
-    P = zeros(n, n)
     Pcol = zeros(n)
-    beta = ones(n)
-    logU = log(perplexity)
 
     # Loop over all datapoints
     progress && (pb = Progress(n, "Computing point perplexities"))
@@ -150,11 +150,11 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
               stop_cheat_iter::Integer = 250, cheat_scale::Number = 12.0,
               verbose::Bool = false, progress::Bool=true)
     verbose && info("Initial X Shape is $(size(X))")
-    ndims < size(X, 2) || throw(ArgumentError("X has fewer dimensions ($(size(X,2))) than ndims=$ndims"))
+    ndims < size(X, 2) || throw(DimensionMismatch("X has fewer dimensions ($(size(X,2))) than ndims=$ndims"))
 
     # Initialize variables
     X = X * 1.0/std(X) # note that X is copied
-    if reduce_dims>0 && reduce_dims < size(X, 2)
+    if 0<reduce_dims<size(X, 2)
         reduce_dims = max(reduce_dims, ndims)
         verbose && info("Preprocessing the data using PCA...")
         X = pca(X, reduce_dims)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -165,7 +165,7 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
             L[i] = (P[i] - Q[i]/sum_Q) * Q[i]
         end
         sum!(Lcolsums, L)
-        for (i, ldiag) in enumerate(Lcolsums)
+        @inbounds for (i, ldiag) in enumerate(Lcolsums)
             L[i, i] -= ldiag
         end
         A_mul_B!(dY, L, Y)
@@ -173,7 +173,7 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
 
         # Perform the update
         momentum = iter <= momentum_switch_iter ? initial_momentum : final_momentum
-        @inbounds for i in eachindex(gains)
+        @inbounds @simd for i in eachindex(gains)
             flag = (dY[i] > 0) == (iY[i] > 0)
             gains[i] = max(flag ? gains[i] * 0.8 : gains[i] + 0.2, min_gain)
             iY[i] = momentum * iY[i] - eta * (gains[i] * dY[i])
@@ -182,8 +182,8 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
         mean!(Ymean, Y)
         @inbounds for j in 1:size(Y, 2)
             YcolMean = Ymean[j]
-            for i in 1:size(Y, 1)
-                Y[i,j] -= YcolMean
+            @simd for i in 1:size(Y, 1)
+                Y[i, j] -= YcolMean
             end
         end
 

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module TSne
 
 using ProgressMeter, Compat.view

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -49,9 +49,9 @@ function x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
         progress && update!(pb, i)
 
         # Compute the Gaussian kernel and entropy for the current precision
-        betai = beta[i]
-        betamin = -Inf
-        betamax =  Inf
+        betai = 1.0
+        betamin = 0.0
+        betamax = Inf
 
         copy!(Di, slice(D, :, i))
         Di[i] = prevfloat(Inf) # exclude D[i,i] from minimum(), yet make it finite and exp(-D[i,i])==0.0
@@ -72,7 +72,7 @@ function x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
                 betai = isfinite(betamax) ? (betai + betamax)/2 : betai*2
             else
                 betamax = betai
-                betai = isfinite(betamin) ? (betai + betamin)/2 : betai/2
+                betai = (betai + betamin)/2
             end
 
             # Recompute the values

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -31,16 +31,16 @@ function Hbeta!(P::AbstractVector, D::AbstractVector, Doffset::Number, beta::Num
 end
 
 """
-    x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
-        [keyword arguments])
+    perplexities(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
+                 [keyword arguments])
 
 Convert `n×d` matrix `X` of point coordinates into `n×n` perplexities matrix `P`.
 Performs a binary search to get P-values in such a way that each conditional
 Gaussian has the same perplexity.
 """
-function x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
-             max_iter::Integer = 50,
-             verbose::Bool=false, progress::Bool=true)
+function perplexities(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
+                      max_iter::Integer = 50,
+                      verbose::Bool=false, progress::Bool=true)
     verbose && info("Computing pairwise distances...")
     (n, d) = size(X)
     sum_XX = sumabs2(X, 2)
@@ -178,7 +178,7 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
     gains = ones(n, ndims)
 
     # Compute P-values
-    P = x2p(X, 1e-5, perplexity, verbose=verbose, progress=progress)
+    P = perplexities(X, 1e-5, perplexity, verbose=verbose, progress=progress)
     P = P + P'
     scale!(P, 1.0/sum(P))
     scale!(P, cheat_scale)  # early exaggeration

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -138,7 +138,7 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
     P = P + P'
     scale!(P, 1.0/sum(P))
     scale!(P, cheat_scale)  # early exaggeration
-    P = max(P, 1e-12)
+    sum_P = cheat_scale
     L = similar(P)
     Ymean = zeros(1, ndims)
     sum_YY = zeros(n, 1)
@@ -196,12 +196,13 @@ function tsne(X::Matrix, ndims::Integer = 2, initial_dims::Integer = 0, max_iter
                     kldiv += p*log(p/q)
                 end
             end
-            kldiv = kldiv + log(sum_Q) # adjust wrt Q scale
+            kldiv = kldiv/sum_P + log(sum_Q/sum_P) # adjust wrt P and Q scales
             info("Iteration #$(iter + 1): KL-divergence is $kldiv")
         end
         # stop cheating with P-values
         if iter == min(max_iter, stop_cheat_iter)
-            scale!(P, 1/cheat_scale)
+            scale!(P, 1/sum_P)
+            sum_P = 1.0
         end
     end
     progress && (finish!(pb))

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -1,6 +1,6 @@
 module TSne
 
-using ProgressMeter
+using ProgressMeter, Compat.view
 
 # Numpy Math.sum => axis = 0 => sum down the columns. axis = 1 => sum along the rows
 # Julia Base.sum => axis = 1 => sum down the columns. axis = 2 => sum along the rows
@@ -53,7 +53,7 @@ function x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
         betamin = 0.0
         betamax = Inf
 
-        copy!(Di, slice(D, :, i))
+        copy!(Di, view(D, :, i))
         Di[i] = prevfloat(Inf) # exclude D[i,i] from minimum(), yet make it finite and exp(-D[i,i])==0.0
         minD = minimum(Di) # distance of i-th point to its closest neighbour
         @inbounds @simd for j in eachindex(Di)
@@ -139,7 +139,7 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter:
     ndims < size(X, 2) || throw(ArgumentError("X has fewer dimensions ($(size(X,2))) than ndims=$ndims"))
 
     # Initialize variables
-    X = scale(X, 1.0/std(X))
+    X = X * 1.0/std(X) # note that X is copied
     if reduce_dims>0 && reduce_dims < size(X, 2)
         reduce_dims = max(reduce_dims, ndims)
         verbose && info("Preprocessing the data using PCA...")

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -108,11 +108,27 @@ function pca{T}(X::Matrix{T}, ndims::Integer = 50)
     return Y
 end
 
-"""
-    Apply t-SNE to `X`, i.e. embed its points into `ndims` dimensions
-    preserving close neighbours.
+"""`tsne(X::Matrix, ndims::Integer=2, reduce_dims::Integer=0, max_iter::Integer=1000)`
+
+    Apply t-SNE (t-Distributed Stochastic Neighbor Embedding) to `X` dataset,
+    i.e. embed its points (rows) into `ndims` dimensions preserving close neighbours.
+
     Different from the orginal implementation,
     the default is not to use PCA for initialization.
+
+    * `reduce_dims` the number of the first dimensions of `X` PCA to use for t-SNE,
+      if 0, all available dimension are used
+    * `pca_init` whether to use the first `ndims` of `X` PCA as the initial t-SNE layout,
+      if `false` (the default), the method is initialized with the random layout
+    * `max_iter` how many iterations of t-SNE to do
+    * `perplexity` the number of "effective neighbours" of a datapoint,
+      typical values are from 5 to 50, the default is 30
+    * `verbose` output informational and diagnostic messages
+    * `progress` display progress meter during t-SNE optimization
+    * `min_gain`, `eta`, `initial_momentum`, `final_momentum`, `momentum_switch_iter`,
+      `stop_cheat_iter`, `cheat_scale` low-level parameters of t-SNE optimization
+
+    See also [Original t-SNE implementation](https://lvdmaaten.github.io/tsne).
 """
 function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter::Integer = 1000, perplexity::Number = 30.0;
               min_gain::Number = 0.01, eta::Number = 200.0, pca_init::Bool = false,

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -115,7 +115,7 @@ end
     the default is not to use PCA for initialization.
 """
 function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter::Integer = 1000, perplexity::Number = 30.0;
-              min_gain::Number = 0.01, eta::Number = 200.0,
+              min_gain::Number = 0.01, eta::Number = 200.0, pca_init::Bool = false,
               initial_momentum::Number = 0.5, final_momentum::Number = 0.8, momentum_switch_iter::Integer = 250,
               stop_cheat_iter::Integer = 250, cheat_scale::Number = 12.0,
               verbose::Bool = false, progress::Bool=true)
@@ -129,7 +129,19 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter:
         X = pca(X, reduce_dims)
     end
     (n, d) = size(X)
-    Y = randn(n, ndims)
+    if !pca_init
+        verbose && info("Starting with random layout...")
+        Y = randn(n, ndims)
+    else
+        verbose && info("Using the first $ndims components of the data PCA as the initial layout...")
+        if reduce_dims >= ndims
+            Y = X[:, 1:ndims] # reuse X PCA
+        else
+            @assert reduce_dims <= 0 # no X PCA
+            Y = pca(X, ndims)
+        end
+    end
+
     dY = zeros(n, ndims)
     iY = zeros(n, ndims)
     gains = ones(n, ndims)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -15,7 +15,8 @@ using ProgressMeter, Compat.view
 export tsne
 
 """
-    Compute the perplexity and the i-th column for a specific value of the precision of a Gaussian distribution.
+Compute the point perplexities `P` given its distances to the other points `D`
+and the precision of Gaussian distribution `beta`.
 """
 function Hbeta!(P::AbstractVector, D::AbstractVector, Doffset::Number, beta::Number)
     @inbounds @simd for j in eachindex(D)
@@ -30,7 +31,12 @@ function Hbeta!(P::AbstractVector, D::AbstractVector, Doffset::Number, beta::Num
 end
 
 """
-    Performs a binary search to get P-values in such a way that each conditional Gaussian has the same perplexity.
+    x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
+        [keyword arguments])
+
+Convert `n×d` matrix `X` of point coordinates into `n×n` perplexities matrix `P`.
+Performs a binary search to get P-values in such a way that each conditional
+Gaussian has the same perplexity.
 """
 function x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
              max_iter::Integer = 50,
@@ -95,9 +101,11 @@ function x2p(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
 end
 
 """
-    Runs PCA on the NxD array `X` in order to reduce its dimensionality to `ndims` dimensions.
+    pca(X::Matrix, ncols::Integer = 50)
 
-    FIXME use PCA routine from JuliaStats?
+Run PCA on `X` to reduce the number of its dimensions to `ndims`.
+
+FIXME use PCA routine from JuliaStats?
 """
 function pca{T}(X::Matrix{T}, ndims::Integer = 50)
     (n, d) = size(X)
@@ -110,29 +118,33 @@ function pca{T}(X::Matrix{T}, ndims::Integer = 50)
     return Y
 end
 
-"""`tsne(X::Matrix, ndims::Integer=2, reduce_dims::Integer=0, max_iter::Integer=1000)`
-
-    Apply t-SNE (t-Distributed Stochastic Neighbor Embedding) to `X` dataset,
-    i.e. embed its points (rows) into `ndims` dimensions preserving close neighbours.
-
-    Different from the orginal implementation,
-    the default is not to use PCA for initialization.
-
-    * `reduce_dims` the number of the first dimensions of `X` PCA to use for t-SNE,
-      if 0, all available dimension are used
-    * `pca_init` whether to use the first `ndims` of `X` PCA as the initial t-SNE layout,
-      if `false` (the default), the method is initialized with the random layout
-    * `max_iter` how many iterations of t-SNE to do
-    * `perplexity` the number of "effective neighbours" of a datapoint,
-      typical values are from 5 to 50, the default is 30
-    * `verbose` output informational and diagnostic messages
-    * `progress` display progress meter during t-SNE optimization
-    * `min_gain`, `eta`, `initial_momentum`, `final_momentum`, `momentum_switch_iter`,
-      `stop_cheat_iter`, `cheat_scale` low-level parameters of t-SNE optimization
-
-    See also [Original t-SNE implementation](https://lvdmaaten.github.io/tsne).
 """
-function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0, max_iter::Integer = 1000, perplexity::Number = 30.0;
+    tsne(X::Matrix, ndims::Integer=2, reduce_dims::Integer=0,
+         max_iter::Integer=1000, perplexity::Number=30.0; [keyword arguments])
+
+Apply t-SNE (t-Distributed Stochastic Neighbor Embedding) to `X`,
+i.e. embed its points (rows) into `ndims` dimensions preserving close neighbours.
+
+Different from the orginal implementation,
+the default is not to use PCA for initialization.
+
+# Arguments
+* `reduce_dims` the number of the first dimensions of `X` PCA to use for t-SNE,
+  if 0, all available dimension are used
+* `pca_init` whether to use the first `ndims` of `X` PCA as the initial t-SNE layout,
+  if `false` (the default), the method is initialized with the random layout
+* `max_iter` how many iterations of t-SNE to do
+* `perplexity` the number of "effective neighbours" of a datapoint,
+  typical values are from 5 to 50, the default is 30
+* `verbose` output informational and diagnostic messages
+* `progress` display progress meter during t-SNE optimization
+* `min_gain`, `eta`, `initial_momentum`, `final_momentum`, `momentum_switch_iter`,
+  `stop_cheat_iter`, `cheat_scale` low-level parameters of t-SNE optimization
+
+See also [Original t-SNE implementation](https://lvdmaaten.github.io/tsne).
+"""
+function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
+              max_iter::Integer = 1000, perplexity::Number = 30.0;
               min_gain::Number = 0.01, eta::Number = 200.0, pca_init::Bool = false,
               initial_momentum::Number = 0.5, final_momentum::Number = 0.8, momentum_switch_iter::Integer = 250,
               stop_cheat_iter::Integer = 250, cheat_scale::Number = 12.0,

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -14,5 +14,9 @@ facts("tsne()") do
         X = Xcenter / Xstd
         Y = tsne(X, 2, 50, 50, 20)
         @fact size(Y) --> (2500, 2)
+        context("PCA for initial layout") do
+            Y = tsne(X, 2, 50, 50, 20, pca_init=true, cheat_scale=1.0, verbose=true)
+            @fact size(Y) --> (2500, 2)
+        end
     end
 end

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -41,7 +41,7 @@ facts("tsne()") do
         Xcenter = X - mean(X)
         Xstd = std(X)
         X = Xcenter / Xstd
-        Y = tsne(X, 2, 50, 50, 20, progress=false)
+        Y = tsne(X, 2, 50, 30, 20, progress=true)
         @fact size(Y) --> (2500, 2)
     end
 end

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -1,11 +1,35 @@
 facts("tsne()") do
+    context("API tests") do
+        iris = dataset("datasets","iris")
+        X = convert(Matrix, iris[:, 1:4])
+        context("verbose=true") do
+            Y = tsne(X, 2, -1, 10, 15, verbose=true)
+            @fact size(Y) --> (150, 2)
+        end
+        context("verbose=false") do
+            Y = tsne(X, 3, -1, 10, 15, verbose=false)
+            @fact size(Y) --> (150, 3)
+        end
+        context("no progress bar") do
+            tsne(X, 2, -1, 10, 15, verbose=true, progress=false)
+        end
+        context("no progress bar, verbose=false") do
+            tsne(X, 2, -1, 10, 15, verbose=false, progress=false)
+        end
+        context("PCA for initial layout") do
+            Y = tsne(X, 2, -1, 10, 15, pca_init=true, cheat_scale=1.0, progress=false)
+            @fact size(Y) --> (150, 2)
+        end
+    end
+
     context("Iris dataset") do
         iris = dataset("datasets","iris")
         X = convert(Matrix, iris[:, 1:4])
-        Y = tsne(X, 3, -1, 1500, 15, verbose=true)
-        @fact size(Y) --> (150, 3)
-
-        context("no progress bar") do
+        context("embed in 3D") do
+            Y = tsne(X, 3, -1, 1500, 15, progress=false)
+            @fact size(Y) --> (150, 3)
+        end
+        context("embed in 2D") do
             Y = tsne(X, 2, 50, 50, 20, progress=false)
             @fact size(Y) --> (150, 2)
         end
@@ -17,11 +41,7 @@ facts("tsne()") do
         Xcenter = X - mean(X)
         Xstd = std(X)
         X = Xcenter / Xstd
-        Y = tsne(X, 2, 50, 50, 20)
+        Y = tsne(X, 2, 50, 50, 20, progress=false)
         @fact size(Y) --> (2500, 2)
-        context("PCA for initial layout") do
-            Y = tsne(X, 2, 50, 50, 20, pca_init=true, cheat_scale=1.0, verbose=true)
-            @fact size(Y) --> (2500, 2)
-        end
     end
 end

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -4,6 +4,11 @@ facts("tsne()") do
         X = convert(Matrix, iris[:, 1:4])
         Y = tsne(X, 3, -1, 1500, 15, verbose=true)
         @fact size(Y) --> (150, 3)
+
+        context("no progress bar") do
+            Y = tsne(X, 2, 50, 50, 20, progress=false)
+            @fact size(Y) --> (150, 2)
+        end
     end
 
     context("MNIST.traindata() dataset") do


### PR DESCRIPTION
Another bunch of fixes and enhancements
- scale the input matrix to avoid degeneration during perplexity calculation
- `Hbeta()`: handle situations when the point is too distant from any other points; previously it resulted in a degenerated `P` distribution
- further reduce the number of array re-allocations
- rename error to KL-divergence, optimize the code, output the divergence as a part of progress meter
- correct the KL-divergence for the first few iterations when we are cheating with the `P` matrix scale
- add `pca_init=true/false` kwarg to `tsne()`. If true, the initial layout is the first `ndims` components of `pca(X)`. It should be a better start than a random layout (in terms of KL-divergence). It also makes the tSNE layouts reproducible.
