### PR TITLE
Performance and Documenation Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Julia t-SNE
 
 Julia port of L.J.P. van der Maaten and G.E. Hintons T-SNE visualisation technique.
 
-Please observe, that it is not extensively tested. 
+Please observe, that it is not extensively tested.
 
 The examples in the 'examples' dir requires you to have Gadfly and RDatasets installed
 
@@ -14,33 +14,30 @@ The examples in the 'examples' dir requires you to have Gadfly and RDatasets ins
 
 For some tips working with t-sne [Klick here] (http://lejon.github.io)
 
-## Basic installation: 
+## Basic installation:
 
   `julia> Pkg.clone("git://github.com/lejon/TSne.jl.git")`
-  
-## Basic API usage: 
-  
+
+## Basic API usage:
+
 ```jl
 using TSne, MNIST
 
-function normalize(A)
-	for col in 1:size(A)[2]
-        	std(A[:,col]) == 0 && continue 
-        	A[:,col] = (A[:,col]-mean(A[:,col])) / std(A[:,col])
-	end
-	A
+function rescale(A, dim::Integer=1)
+    res = A .- mean(A, dim)
+    res ./= map!(x -> x > 0.0 ? x : 1.0, std(A, dim))
+    res
 end
 
 data, labels = traindata()
-data = data'
-data = data[1:2500,:]
+data = convert(Matrix{Float64}, data[:, 1:2500])'
 # Normalize the data, this should be done if there are large scale differences in the dataset
-X = normalize(float(data)) 
+X = rescale(data, 1)
 
 Y = tsne(X, 2, 50, 1000, 20.0)
 
 using Gadfly
-labels = [string(i) for i in labels[1:2500]]
+labels = convert(Vector{String}, labels[1:2500])
 theplot = plot(x=Y[:,1], y=Y[:,2], color=labels)
 draw(PDF("myplot.pdf", 4inch, 3inch), theplot)
 ```

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 [![Travis](https://travis-ci.org/lejon/TSne.jl.svg?branch=master)](https://travis-ci.org/lejon/TSne.jl)
 [![Coveralls](https://coveralls.io/repos/github/lejon/TSne.jl/badge.svg?branch=master)](https://coveralls.io/github/lejon/TSne.jl?branch=master)
 
-Julia t-SNE
-===========
+t-SNE (t-Stochastic Neighbor Embedding)
+=======================================
 
-Julia port of L.J.P. van der Maaten and G.E. Hintons T-SNE visualisation technique.
+Julia implementation of L.J.P. van der Maaten and G.E. Hintons [t-SNE visualisation technique](https://lvdmaaten.github.io/tsne/).
 
-Please observe, that it is not extensively tested.
+Please observe that it is not yet extensively tested.
 
-The examples in the 'examples' dir requires you to have Gadfly and RDatasets installed
+The scripts in the `examples` folder require `Gadfly`, `MNIST` and `RDatasets` Julia packages.
 
-**Please note:** At some point something changed in Julia which caused poor results, it took a while before I noted this but now  I have updated the implementation so that it works again. See the link below for images rendered using this implementation.
-
-For some tips working with t-sne [Klick here] (http://lejon.github.io)
-
-## Basic installation:
+## Installation
 
   `julia> Pkg.clone("git://github.com/lejon/TSne.jl.git")`
 
-## Basic API usage:
+## Basic API usage
 
 ```jl
 using TSne, MNIST
@@ -44,8 +40,12 @@ draw(PDF("myplot.pdf", 4inch, 3inch), theplot)
 
 ![](example.png)
 
-## Stand Alone Usage
+## Command line usage
 
 ```julia demo-csv.jl haveheader --labelcol=5 iris-headers.csv```
 
-Creates myplot.pdf with TSne result visuallized using Gadfly.
+Creates `myplot.pdf` with t-SNE result visualized using `Gadfly.jl`.
+
+## See also
+ * [Some tips working with t-SNE](http://lejon.github.io)
+ * [How to Use t-SNE Effectively](http://distill.pub/2016/misread-tsne/)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 Compat 0.9
-FactCheck
+BaseTestNext
 RDatasets
 MNIST
 ProgressMeter

--- a/examples/demo.jl
+++ b/examples/demo.jl
@@ -1,55 +1,55 @@
 using Gadfly
 using TSne
 
-function normalize(A)
-	for col in 1:size(A)[2]
-        	std(A[:,col]) == 0 && continue 
-        	A[:,col] = (A[:,col]-mean(A[:,col])) / std(A[:,col])
-	end
-	A
+"""
+Normalize `A` columns, so that the mean and standard deviation
+of each column are 0 and 1, resp.
+"""
+function rescale(A, dim::Integer=1)
+    res = A .- mean(A, dim)
+    res ./= map!(x -> x > 0.0 ? x : 1.0, std(A, dim))
+    res
 end
 
-if length(ARGS)==0 
+if length(ARGS)==0
     println("usage:\n\tjulia demo.jl iris\n\tjulia demo.jl mnist")
     exit(0)
 end
 
-use_iris = ARGS[1] == "iris"
-lables = ()
-
-if use_iris
+if ARGS[1] == "iris"
     using RDatasets
     println("Using Iris dataset.")
     iris = dataset("datasets","iris")
-    X = float(convert(Array,iris[:,1:4]))
-    labels = iris[:,5]
+    X = convert(Matrix{Float64}, iris[:, 1:4])
+    labels = iris[:, 5]
     plotname = "iris"
     initial_dims = -1
     iterations = 1500
     perplexity = 15
-else
+elseif ARGS[1] == "mnist"
     using MNIST
+    println("Using MNIST dataset.")
     X, labels = traindata()
-    labels = labels[1:2500]
-    X = X'
-    X = X[1:2500,:]
-    X = normalize(X)
+    npts = min(2500, size(X, 2), size(labels))
+    labels = labels[1:npts]
+    X = rescale(X[:, 1:npts]')
     plotname = "mnist"
     initial_dims = 50
     iterations = 1000
     perplexity = 20
+else
+    error("Unknown dataset \"", ARGS[1], "\"")
 end
 
-println("X dimensions are: " * string(size(X)))
+println("X dimensions are: ", size(X))
 Y = tsne(X, 2, initial_dims, iterations, perplexity)
-println("Y dimensions are: " * string(size(Y)))
+println("Y dimensions are: ", size(Y))
 
-writecsv(plotname*"_tsne_out.csv",Y)
-lbloutfile = open("labels.txt", "w")
-writedlm(lbloutfile,labels)
-close(lbloutfile)
+writecsv(plotname*"_tsne_out.csv", Y)
+open("labels.txt", "w") do io
+    writedlm(io, labels)
+end
 
 theplot = plot(x=Y[:,1], y=Y[:,2], color=labels)
-
 draw(PDF(plotname*".pdf", 4inch, 3inch), theplot)
 #draw(SVG(plotname*".svg", 4inch, 3inch), theplot)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -43,7 +43,7 @@ function perplexities(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
                       verbose::Bool=false, progress::Bool=true)
     verbose && info("Computing pairwise distances...")
     (n, d) = size(X)
-    sum_XX = sumabs2(X, 2)
+    sum_XX = sum(abs2, X, 2)
     D = -2 * (X*X') .+ sum_XX .+ sum_XX' # euclidean distances between the points
     P = zeros(n, n) # perplexities matrix
     beta = ones(n)  # vector of Normal distribution precisions for each point
@@ -194,7 +194,7 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
     Q = similar(P)
     for iter in 1:max_iter
         # Compute pairwise affinities
-        sumabs2!(sum_YY, Y)
+        sum!(abs2, sum_YY, Y)
         # FIXME profiling indicates a lot of time is lost in copytri!()
         A_mul_Bt!(Q, Y, Y)
         @inbounds for j in 1:size(Q, 2)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -128,7 +128,7 @@ i.e. embed its points (rows) into `ndims` dimensions preserving close neighbours
 Different from the orginal implementation,
 the default is not to use PCA for initialization.
 
-# Arguments
+### Arguments
 * `reduce_dims` the number of the first dimensions of `X` PCA to use for t-SNE,
   if 0, all available dimension are used
 * `pca_init` whether to use the first `ndims` of `X` PCA as the initial t-SNE layout,

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -195,8 +195,7 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
     for iter in 1:max_iter
         # Compute pairwise affinities
         sum!(abs2, sum_YY, Y)
-        # FIXME profiling indicates a lot of time is lost in copytri!()
-        A_mul_Bt!(Q, Y, Y)
+        BLAS.syrk!('U', 'N', 1.0, Y, 0.0, Q) # Q=YY^T, updates only the upper tri of Q
         @inbounds for j in 1:size(Q, 2)
             Q[j,j] = 0.0
             @simd for i in 1:(j-1)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -218,8 +218,10 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
         # Perform the update
         momentum = iter <= momentum_switch_iter ? initial_momentum : final_momentum
         @inbounds @simd for i in eachindex(gains)
-            flag = (dY[i] > 0) == (iY[i] > 0)
-            gains[i] = max(flag ? gains[i] * 0.8 : gains[i] + 0.2, min_gain)
+            gains[i] = max(ifelse((dY[i] > 0) == (iY[i] > 0),
+                                  gains[i] * 0.8,
+                                  gains[i] + 0.2),
+                           min_gain)
             iY[i] = momentum * iY[i] - eta * (gains[i] * dY[i])
             Y[i] += iY[i]
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,10 @@
-using FactCheck, RDatasets, TSne, MNIST
+using RDatasets, TSne, MNIST
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 my_tests = [
   "test_tsne.jl",
@@ -7,5 +13,3 @@ my_tests = [
 for t in my_tests
   include(t)
 end
-
-exitstatus()

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -1,47 +1,47 @@
-facts("tsne()") do
-    context("API tests") do
+@testset "tsne()" begin
+    @testset "API tests" begin
         iris = dataset("datasets","iris")
         X = convert(Matrix, iris[:, 1:4])
-        context("verbose=true") do
+        @testset "verbose=true" begin
             Y = tsne(X, 2, -1, 10, 15, verbose=true)
-            @fact size(Y) --> (150, 2)
+            @test size(Y) == (150, 2)
         end
-        context("verbose=false") do
+        @testset "verbose=false" begin
             Y = tsne(X, 3, -1, 10, 15, verbose=false)
-            @fact size(Y) --> (150, 3)
+            @test size(Y) == (150, 3)
         end
-        context("no progress bar") do
+        @testset "no progress bar" begin
             tsne(X, 2, -1, 10, 15, verbose=true, progress=false)
         end
-        context("no progress bar, verbose=false") do
+        @testset "no progress bar, verbose=false" begin
             tsne(X, 2, -1, 10, 15, verbose=false, progress=false)
         end
-        context("PCA for initial layout") do
+        @testset "PCA for initial layout" begin
             Y = tsne(X, 2, -1, 10, 15, pca_init=true, cheat_scale=1.0, progress=false)
-            @fact size(Y) --> (150, 2)
+            @test size(Y) == (150, 2)
         end
     end
 
-    context("Iris dataset") do
+    @testset "Iris dataset" begin
         iris = dataset("datasets","iris")
         X = convert(Matrix, iris[:, 1:4])
-        context("embed in 3D") do
+        @testset "embed in 3D" begin
             Y = tsne(X, 3, -1, 1500, 15, progress=false)
-            @fact size(Y) --> (150, 3)
+            @test size(Y) == (150, 3)
         end
-        context("embed in 2D") do
+        @testset "embed in 2D" begin
             Y = tsne(X, 2, 50, 50, 20, progress=false)
-            @fact size(Y) --> (150, 2)
+            @test size(Y) == (150, 2)
         end
     end
 
-    context("MNIST.traindata() dataset") do
+    @testset "MNIST.traindata() dataset" begin
         train_data, labels = MNIST.traindata()
         X = train_data[:, 1:2500]'
         Xcenter = X - mean(X)
         Xstd = std(X)
         X = Xcenter / Xstd
         Y = tsne(X, 2, 50, 30, 20, progress=true)
-        @fact size(Y) --> (2500, 2)
+        @test size(Y) == (2500, 2)
     end
 end

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -1,38 +1,26 @@
 @testset "tsne()" begin
     @testset "API tests" begin
-        iris = dataset("datasets","iris")
+        iris = dataset("datasets", "iris")
         X = convert(Matrix, iris[:, 1:4])
-        @testset "verbose=true" begin
-            Y = tsne(X, 2, -1, 10, 15, verbose=true)
-            @test size(Y) == (150, 2)
-        end
-        @testset "verbose=false" begin
-            Y = tsne(X, 3, -1, 10, 15, verbose=false)
-            @test size(Y) == (150, 3)
-        end
-        @testset "no progress bar" begin
-            tsne(X, 2, -1, 10, 15, verbose=true, progress=false)
-        end
-        @testset "no progress bar, verbose=false" begin
-            tsne(X, 2, -1, 10, 15, verbose=false, progress=false)
-        end
-        @testset "PCA for initial layout" begin
-            Y = tsne(X, 2, -1, 10, 15, pca_init=true, cheat_scale=1.0, progress=false)
-            @test size(Y) == (150, 2)
-        end
+        Y = tsne(X, 2, -1, 10, 15, verbose=true)
+        @test size(Y) == (150, 2)
+        Y = tsne(X, 3, -1, 10, 15, verbose=false)
+        @test size(Y) == (150, 3)
+        tsne(X, 2, -1, 10, 15, verbose=true, progress=false)
+        tsne(X, 2, -1, 10, 15, verbose=false, progress=false)
+        Y = tsne(X, 2, -1, 10, 15, pca_init=true, cheat_scale=1.0, progress=false)
+        @test size(Y) == (150, 2)
     end
 
     @testset "Iris dataset" begin
-        iris = dataset("datasets","iris")
+        iris = dataset("datasets", "iris")
         X = convert(Matrix, iris[:, 1:4])
-        @testset "embed in 3D" begin
-            Y = tsne(X, 3, -1, 1500, 15, progress=false)
-            @test size(Y) == (150, 3)
-        end
-        @testset "embed in 2D" begin
-            Y = tsne(X, 2, 50, 50, 20, progress=false)
-            @test size(Y) == (150, 2)
-        end
+        # embed in 3D
+        Y3d = tsne(X, 3, -1, 1500, 15, progress=false)
+        @test size(Y3d) == (150, 3)
+        # embed in 2D
+        Y2d = tsne(X, 2, 50, 50, 20, progress=false)
+        @test size(Y2d) == (150, 2)
     end
 
     @testset "MNIST.traindata() dataset" begin

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -1,35 +1,60 @@
 @testset "tsne()" begin
     @testset "API tests" begin
+        info("t1")
         iris = dataset("datasets", "iris")
+        info("t2")
         X = convert(Matrix, iris[:, 1:4])
+        info("t3")
         Y = tsne(X, 2, -1, 10, 15, verbose=true)
+        info("t4")
         @test size(Y) == (150, 2)
+        info("t5")
         Y = tsne(X, 3, -1, 10, 15, verbose=false)
+        info("t6")
         @test size(Y) == (150, 3)
+        info("t7")
         tsne(X, 2, -1, 10, 15, verbose=true, progress=false)
+        info("t8")
         tsne(X, 2, -1, 10, 15, verbose=false, progress=false)
+        info("t9")
         Y = tsne(X, 2, -1, 10, 15, pca_init=true, cheat_scale=1.0, progress=false)
+        info("t10")
         @test size(Y) == (150, 2)
+        info("t11")
     end
 
     @testset "Iris dataset" begin
+        info("t12")
         iris = dataset("datasets", "iris")
+        info("t13")
         X = convert(Matrix, iris[:, 1:4])
         # embed in 3D
+        info("t14")
         Y3d = tsne(X, 3, -1, 1500, 15, progress=false)
+        info("t15")
         @test size(Y3d) == (150, 3)
         # embed in 2D
+        info("t16")
         Y2d = tsne(X, 2, 50, 50, 20, progress=false)
+        info("t17")
         @test size(Y2d) == (150, 2)
     end
 
     @testset "MNIST.traindata() dataset" begin
+        info("t18")
         train_data, labels = MNIST.traindata()
+        info("t19")
         X = train_data[:, 1:2500]'
+        info("t20")
         Xcenter = X - mean(X)
+        info("t21")
         Xstd = std(X)
+        info("t22")
         X = Xcenter / Xstd
+        info("t23")
         Y = tsne(X, 2, 50, 30, 20, progress=true)
+        info("t24")
         @test size(Y) == (2500, 2)
+        info("t25")
     end
 end


### PR DESCRIPTION
It's me again with some changes:
* speed up t-SNE by using `BLAS.syrk()` for `Q=YY^T` and calculating only the upper triangle of the symmetric matrices (MNIST test times go from 33-36 secs to 23-26 secs on my laptop)
* replace `FactCheck` with the built-in `@testset` (requires Julia 0.5, `BaseTestNext` used for backward compatibility with 0.4)
* cleanup examples code
* edit README

I can split the method improvements and the examples/documentation changes into separate PRs, if you would like to review it separately.