### PR TITLE
User-specified distances

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
+Distances
 ProgressMeter

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -191,7 +191,7 @@ function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
     for iter in 1:max_iter
         # Compute pairwise affinities
         sum!(abs2, sum_YY, Y)
-        BLAS.syrk!('U', 'N', 1.0, Y, 0.0, Q) # Q=YY^T, updates only the upper tri of Q
+        BLAS.syrk!('U', 'N', 1.0, Y, 0.0, Q) # Q=YY', updates only the upper tri of Q
         @inbounds for j in 1:size(Q, 2)
             sum_YYj_p1 = 1.0 + sum_YY[j]
             Qj = view(Q, :, j)

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -4,14 +4,6 @@ module TSne
 
 using ProgressMeter
 
-# Numpy Math.sum => axis = 0 => sum down the columns. axis = 1 => sum along the rows
-# Julia Base.sum => axis = 1 => sum down the columns. axis = 2 => sum along the rows
-
-#
-#  tsne.jl
-#
-#  This is a straight off Julia port of Laurens van der Maatens python implementation of tsne
-
 export tsne
 
 """

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -23,14 +23,14 @@ function Hbeta!(P::AbstractVector, D::AbstractVector, beta::Number)
 end
 
 """
-    perplexities(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
+    perplexities(X::AbstractMatrix, tol::Number = 1e-5, perplexity::Number = 30.0;
                  [keyword arguments])
 
 Convert `n×d` matrix `X` of point coordinates into `n×n` perplexities matrix `P`.
 Performs a binary search to get P-values in such a way that each conditional
 Gaussian has the same perplexity.
 """
-function perplexities(X::Matrix, tol::Number = 1e-5, perplexity::Number = 30.0;
+function perplexities(X::AbstractMatrix, tol::Number = 1e-5, perplexity::Number = 30.0;
                       max_iter::Integer = 50,
                       verbose::Bool=false, progress::Bool=true)
     verbose && info("Computing pairwise distances...")
@@ -99,7 +99,8 @@ Run PCA on `X` to reduce the number of its dimensions to `ndims`.
 
 FIXME use PCA routine from JuliaStats?
 """
-function pca{T}(X::Matrix{T}, ndims::Integer = 50)
+function pca(X::AbstractMatrix, ndims::Integer = 50)
+    T = eltype(X)
     (n, d) = size(X)
     X = X - repmat(mean(X, 1), n, 1)
     C = (X' * X) ./ (size(X,1)-1)
@@ -138,7 +139,7 @@ the default is not to use PCA for initialization.
 
 See also [Original t-SNE implementation](https://lvdmaaten.github.io/tsne).
 """
-function tsne(X::Matrix, ndims::Integer = 2, reduce_dims::Integer = 0,
+function tsne(X::AbstractMatrix, ndims::Integer = 2, reduce_dims::Integer = 0,
               max_iter::Integer = 1000, perplexity::Number = 30.0;
               min_gain::Number = 0.01, eta::Number = 200.0, pca_init::Bool = false,
               initial_momentum::Number = 0.5, final_momentum::Number = 0.8, momentum_switch_iter::Integer = 250,

--- a/src/TSne.jl
+++ b/src/TSne.jl
@@ -100,15 +100,12 @@ Run PCA on `X` to reduce the number of its dimensions to `ndims`.
 FIXME use PCA routine from JuliaStats?
 """
 function pca(X::AbstractMatrix, ndims::Integer = 50)
-    T = eltype(X)
     (n, d) = size(X)
-    X = X - repmat(mean(X, 1), n, 1)
-    C = (X' * X) ./ (size(X,1)-1)
-    l, M = eig(C)
-    sorder = sortperm(l, rev=true)
-    M = M[:, sorder]::Matrix{T}
-    Y = X * M[:, 1:min(d, ndims)]
-    return Y
+    (d <= ndims) && return X
+    X = X .- mean(X, 1)
+    C = Symmetric((X' * X) ./ (n-1))
+    Ceig = eigfact(C, 1:ndims)
+    return X * Ceig.vectors
 end
 
 # K-L divergence element

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using TSne
 using RDatasets
 using MNIST
+using Distances
 using Base.Test
 
 my_tests = [

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -28,6 +28,11 @@
                      3, -1, 10, 15, distance=cityblock, verbose=false)
             @test size(Y) == (150, 3)
         end
+
+        @testset "distance isa Distances.Metric" begin
+            Y = tsne(X, 3, -1, 10, 15, distance=Minkowski(0.5), verbose=false)
+            @test size(Y) == (150, 3)
+        end
     end
 
     @testset "Iris dataset" begin

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -1,7 +1,7 @@
 @testset "tsne()" begin
     @testset "API tests" begin
         iris = dataset("datasets", "iris")
-        X = convert(Matrix, iris[:, 1:4])
+        X = convert(Matrix{Float64}, iris[:, 1:4])
         Y = tsne(X, 2, -1, 10, 15, verbose=true)
         @test size(Y) == (150, 2)
         Y = tsne(X, 3, -1, 10, 15, verbose=false)
@@ -14,7 +14,7 @@
 
     @testset "Iris dataset" begin
         iris = dataset("datasets", "iris")
-        X = convert(Matrix, iris[:, 1:4])
+        X = convert(Matrix{Float64}, iris[:, 1:4])
         # embed in 3D
         Y3d = tsne(X, 3, -1, 100, 15, progress=false)
         @test size(Y3d) == (150, 3)

--- a/test/test_tsne.jl
+++ b/test/test_tsne.jl
@@ -10,6 +10,24 @@
         tsne(X, 2, -1, 10, 15, verbose=false, progress=false)
         Y = tsne(X, 2, -1, 10, 15, pca_init=true, cheat_scale=1.0, progress=false)
         @test size(Y) == (150, 2)
+
+        @testset "distance = true" begin
+            @test_throws ArgumentError tsne(X, 3, -1, 10, 15, distance=true, verbose=false)
+            XX = pairwise(CosineDist(), X')
+            Y = tsne(XX, 3, -1, 10, 15, distance=true, verbose=false)
+            @test size(Y) == (150, 3)
+        end
+
+        @testset "distance isa Function" begin
+            Y = tsne(X, 3, -1, 10, 15, distance=cityblock, verbose=false)
+            @test size(Y) == (150, 3)
+        end
+
+        @testset "X isa Vector, distance isa Function" begin
+            Y = tsne([view(X, i, :) for i in 1:size(X, 1)],
+                     3, -1, 10, 15, distance=cityblock, verbose=false)
+            @test size(Y) == (150, 3)
+        end
     end
 
     @testset "Iris dataset" begin


### PR DESCRIPTION
Basically, it's #16 with my suggestions + support for specifying metrics from `Distances.jl`.
We still have a single `tsne()` method, but keyarg `distance=` allows specifying how to treat `X` and how to calculate distance.